### PR TITLE
feat: add ability to add new text through modal interface

### DIFF
--- a/app/app-server.py
+++ b/app/app-server.py
@@ -20,6 +20,7 @@ class TranslationApp:
         
         # Navigational routes
         self.app.add_url_rule("/", "index", self.index, methods=["GET", "POST"])
+        self.app.add_url_rule("/new", "new", self.new, methods=["GET", "POST"])
         self.app.add_url_rule("/translate", "translate", self.translate, methods=["GET", "POST"])
         self.app.add_url_rule("/review", "review", self.review, methods=["GET", "POST"])
         self.app.add_url_rule("/commit", "commit", self.commit, methods=["GET"])
@@ -39,12 +40,18 @@ class TranslationApp:
         self.app.add_url_rule("/history", "history", self.history, methods=["GET"])
         self.app.add_url_rule("/get-context", "get_context", self.get_context, methods=["POST"])
         self.app.add_url_rule("/autosave", "autosave", self.autosave, methods=["POST"])
+        self.app.add_url_rule("/create-text", "create_text", self.create_text, methods=["POST"])
 
     ## Navigation routes
     def index(self):
 
         from routes.index import index
         return index(self)
+    
+    def new(self):
+
+        from routes.new import new
+        return new(self)
     
     def translate(self):
 
@@ -113,6 +120,11 @@ class TranslationApp:
 
         from routes.autosave import autosave
         return autosave(self)
+    
+    def create_text(self):
+
+        from routes.create_text import create_text
+        return create_text(self)
         
 
     def run(self):

--- a/app/routes/create_text.py
+++ b/app/routes/create_text.py
@@ -1,0 +1,75 @@
+from flask import request, jsonify, session
+import os
+import pandas as pd
+import csv
+
+def create_text(self):
+    """
+    Handles the POST request to create a new text file.
+    
+    Expected POST parameters:
+    - name: The name of the new file (without extension)
+    - content: The content of the new file (Tibetan text)
+    
+    Returns:
+    - JSON response with success/error message
+    """
+    try:
+        # Get data from request
+        data = request.get_json()
+        name = data.get('name', '').strip()
+        content = data.get('content', '').strip()
+        
+        # Validate input
+        if not name:
+            return jsonify({'status': 'error', 'message': 'File name is required'}), 400
+        
+        if not content:
+            return jsonify({'status': 'error', 'message': 'Content is required'}), 400
+        
+        # Remove .csv extension if it exists in the input name
+        if name.endswith('.csv'):
+            name = name[:-4]
+            
+        # Store the base name (without extension) for session and display
+        base_name = name
+            
+        # Add .csv extension for the actual file
+        file_name = name + '.csv'
+        
+        # Check if file already exists
+        file_path = os.path.join(self.csv_file_path, file_name)
+        if os.path.exists(file_path):
+            return jsonify({'status': 'error', 'message': 'A file with this name already exists'}), 400
+        
+        # Process content - split by newlines and remove empty lines
+        lines = [line for line in content.split('\n') if line.strip()]
+        
+        # Create DataFrame with Tibetan text, empty translation column, style column, and empty notes column
+        df = pd.DataFrame({
+            'source': lines,
+            'target': [''] * len(lines),
+            'style': ['Normal'] * len(lines),
+            'notes': [''] * len(lines)  # Add fourth column to ensure trailing tilde after "Normal"
+        })
+        
+        # Save to CSV file with tilde (~) separator, without quoting
+        df.to_csv(file_path, 
+                 index=False, 
+                 header=False, 
+                 sep="~", 
+                 quoting=csv.QUOTE_NONE,
+                 encoding="utf-8",
+                 escapechar='\\')  # Escape character needed when QUOTE_NONE is used
+        
+        # Update session with the new file (without .csv extension)
+        session['selected_file'] = base_name
+        
+        return jsonify({
+            'status': 'success', 
+            'message': f'File "{base_name}" created successfully',
+            'filename': base_name
+        })
+        
+    except Exception as e:
+        return jsonify({'status': 'error', 'message': str(e)}), 500 

--- a/app/routes/index.py
+++ b/app/routes/index.py
@@ -1,7 +1,7 @@
 def index(self):
     
     import os
-    from flask import render_template, request
+    from flask import render_template, request, session
 
     from utils.read_csv import read_csv
     # Gather base filenames (without extensions)
@@ -17,12 +17,17 @@ def index(self):
     # Get user selection from the form (POST). Returns None if nothing posted.
     self.selected = request.form.get('filename')
 
-    # If no file is selected, select the first in dir listing 
+    # If no file is selected from the form, check if there's a file in the session
     if self.selected is None:
-        self.selected = self.all_files[0]
+        # Check if there's a selected file in the session
+        self.selected = session.get('selected_file')
+        
+        # If still no file is selected, select the first in dir listing
+        if self.selected is None or self.selected not in self.all_files:
+            self.selected = self.all_files[0] if self.all_files else None
 
     # Construct the .csv filename from the selected base name
-    self.filename = self.selected + '.csv'
+    self.filename = self.selected + '.csv' if self.selected else None
     
     # Read the CSV data
     self.data = read_csv(self)

--- a/app/routes/new.py
+++ b/app/routes/new.py
@@ -1,0 +1,18 @@
+from flask import render_template, request, session
+import os
+
+def new(self):
+    """
+    Renders the page with the modal for adding new text.
+    """
+    # Get list of available files (without extensions)
+    files = [f.replace('.csv', '') for f in os.listdir(self.csv_file_path) if f.endswith('.csv')]
+    
+    # If no files, provide a default empty list
+    if not files:
+        files = []
+    
+    # Get selected file from session or use the first file
+    selected = session.get('selected_file', files[0] if files else None)
+    
+    return render_template('new.html', files=files, selected=selected) 

--- a/app/templates/new.html
+++ b/app/templates/new.html
@@ -1,0 +1,301 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Add New Text - Translation Editor</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <style>
+        /* Modal specific styles */
+        .new-text-container {
+            max-width: 800px;
+            margin: 50px auto;
+            padding: 30px;
+            background-color: #fff;
+            border-radius: 12px;
+            box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
+        }
+        
+        .new-text-title {
+            font-family: 'SF Pro Display', -apple-system, BlinkMacSystemFont, sans-serif;
+            font-size: 24px;
+            font-weight: 500;
+            color: #1d1d1f;
+            margin-bottom: 20px;
+        }
+        
+        .form-group {
+            margin-bottom: 20px;
+        }
+        
+        .form-label {
+            display: block;
+            font-family: 'SF Pro Text', -apple-system, BlinkMacSystemFont, sans-serif;
+            font-size: 14px;
+            font-weight: 500;
+            color: #1d1d1f;
+            margin-bottom: 8px;
+        }
+        
+        .form-input {
+            width: 100%;
+            padding: 10px 14px;
+            font-family: 'SF Pro Text', -apple-system, BlinkMacSystemFont, sans-serif;
+            font-size: 14px;
+            border: 1px solid #d2d2d7;
+            border-radius: 6px;
+            background-color: #fff;
+            color: #1d1d1f;
+            transition: border-color 0.2s ease;
+            box-sizing: border-box;
+        }
+        
+        .form-input:focus {
+            outline: none;
+            border-color: #0071e3;
+            box-shadow: 0 0 0 3px rgba(0, 113, 227, 0.1);
+        }
+        
+        .form-textarea {
+            width: 100%;
+            height: 300px;
+            padding: 10px 14px;
+            font-family: 'Noto Serif Tibetan', serif;
+            font-size: 18px;
+            border: 1px solid #d2d2d7;
+            border-radius: 6px;
+            background-color: #fff;
+            color: #1d1d1f;
+            resize: vertical;
+            transition: border-color 0.2s ease;
+            box-sizing: border-box;
+        }
+        
+        .form-textarea:focus {
+            outline: none;
+            border-color: #0071e3;
+            box-shadow: 0 0 0 3px rgba(0, 113, 227, 0.1);
+        }
+        
+        .button-container {
+            display: flex;
+            justify-content: flex-end;
+            margin-top: 20px;
+        }
+        
+        .submit-button {
+            background-color: #0071e3;
+            color: #fff;
+            font-family: 'SF Pro Text', -apple-system, BlinkMacSystemFont, sans-serif;
+            font-size: 14px;
+            font-weight: 500;
+            padding: 8px 18px;
+            border: none;
+            border-radius: 6px;
+            cursor: pointer;
+            transition: background-color 0.2s ease;
+        }
+        
+        .submit-button:hover {
+            background-color: #0077ed;
+        }
+        
+        .submit-button:focus {
+            outline: none;
+            box-shadow: 0 0 0 3px rgba(0, 113, 227, 0.3);
+        }
+        
+        .error-message {
+            color: #ff3b30;
+            font-family: 'SF Pro Text', -apple-system, BlinkMacSystemFont, sans-serif;
+            font-size: 14px;
+            margin-top: 5px;
+            display: none;
+        }
+        
+        .success-message {
+            color: #34c759;
+            font-family: 'SF Pro Text', -apple-system, BlinkMacSystemFont, sans-serif;
+            font-size: 14px;
+            margin-top: 5px;
+            display: none;
+        }
+        
+        /* Dark mode support */
+        @media (prefers-color-scheme: dark) {
+            .new-text-container {
+                background-color: #1c1c1e;
+            }
+            
+            .new-text-title {
+                color: #f5f5f7;
+            }
+            
+            .form-label {
+                color: #f5f5f7;
+            }
+            
+            .form-input, .form-textarea {
+                background-color: #2c2c2e;
+                border-color: #3a3a3c;
+                color: #f5f5f7;
+            }
+            
+            .form-input:focus, .form-textarea:focus {
+                border-color: #0071e3;
+            }
+        }
+    </style>
+</head>
+<body>
+   
+    <header class="apple-nav">
+        <div class="nav-container">
+            <div class="nav-left">
+                <a href="/" class="app-logo">
+                    <img src="{{ url_for('static', filename='image.png') }}" alt="App Logo" class="nav-logo">
+                </a>
+                <form method="POST" action="/" class="file-selector-form">
+                    <select id="filename" name="filename" onchange="this.form.submit()" class="apple-select">
+                        {% for f in files %}
+                            <option value="{{ f }}"
+                                {% if f == selected %}selected{% endif %}>
+                                {{ f }}
+                            </option>
+                        {% endfor %}
+                    </select>
+                </form>
+            </div>
+            
+            <div class="nav-right">
+                <a href="/new" class="nav-button" style="background-color: #0071e3; color: white;">New</a>
+                <a href="/translate" class="nav-button">Translate</a>
+                <a href="/review" class="nav-button">Review</a>
+                <a href="/commit" class="nav-button">Commit</a>
+                <a href="/publish" class="nav-button">Publish</a>
+                
+                <form id="search-form" action="/glossary" method="POST" class="search-container">
+                    <div class="search-wrapper">
+                        <svg class="search-icon" width="16" height="16" viewBox="0 0 16 16">
+                            <path d="M6.5 12C9.53757 12 12 9.53757 12 6.5C12 3.46243 9.53757 1 6.5 1C3.46243 1 1 3.46243 1 6.5C1 9.53757 3.46243 12 6.5 12Z" fill="none" stroke="currentColor" stroke-width="1.5"/>
+                            <path d="M11 11L15 15" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+                        </svg>
+                        <input type="text" id="search-box" name="search_term" placeholder="Search...">
+                    </div>
+                </form>
+            </div>
+        </div>
+    </header>
+
+    <div class="new-text-container">
+        <h1 class="new-text-title">Add New Text</h1>
+        
+        <div class="form-group">
+            <label for="text-name" class="form-label">Text Name</label>
+            <input type="text" id="text-name" class="form-input" placeholder="Enter a name for the text file">
+            <div id="name-error" class="error-message"></div>
+        </div>
+        
+        <div class="form-group">
+            <label for="text-content" class="form-label">Tibetan Text Content</label>
+            <textarea id="text-content" class="form-textarea" placeholder="Paste or type Tibetan text here"></textarea>
+            <div id="content-error" class="error-message"></div>
+        </div>
+        
+        <div class="button-container">
+            <button id="add-text-button" class="submit-button">Add Text</button>
+        </div>
+        
+        <div id="success-message" class="success-message"></div>
+    </div>
+
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            const addTextButton = document.getElementById('add-text-button');
+            const textNameInput = document.getElementById('text-name');
+            const textContentInput = document.getElementById('text-content');
+            const nameError = document.getElementById('name-error');
+            const contentError = document.getElementById('content-error');
+            const successMessage = document.getElementById('success-message');
+            
+            addTextButton.addEventListener('click', function() {
+                // Reset error messages
+                nameError.style.display = 'none';
+                contentError.style.display = 'none';
+                successMessage.style.display = 'none';
+                
+                // Get input values
+                const name = textNameInput.value.trim();
+                const content = textContentInput.value.trim();
+                
+                // Validate input
+                let isValid = true;
+                
+                if (!name) {
+                    nameError.textContent = 'Please enter a name for the text file';
+                    nameError.style.display = 'block';
+                    isValid = false;
+                }
+                
+                if (!content) {
+                    contentError.textContent = 'Please enter the Tibetan text content';
+                    contentError.style.display = 'block';
+                    isValid = false;
+                }
+                
+                if (isValid) {
+                    // Disable button to prevent multiple submissions
+                    addTextButton.disabled = true;
+                    addTextButton.textContent = 'Adding...';
+                    
+                    // Send request to create text
+                    fetch('/create-text', {
+                        method: 'POST',
+                        headers: {
+                            'Content-Type': 'application/json'
+                        },
+                        body: JSON.stringify({
+                            name: name,
+                            content: content
+                        })
+                    })
+                    .then(response => response.json())
+                    .then(data => {
+                        // Re-enable button
+                        addTextButton.disabled = false;
+                        addTextButton.textContent = 'Add Text';
+                        
+                        if (data.status === 'success') {
+                            // Show success message
+                            successMessage.textContent = data.message;
+                            successMessage.style.display = 'block';
+                            
+                            // Clear form
+                            textNameInput.value = '';
+                            textContentInput.value = '';
+                            
+                            // Redirect to home page after a delay
+                            setTimeout(function() {
+                                window.location.href = '/';
+                            }, 1500);
+                        } else {
+                            // Show error message
+                            nameError.textContent = data.message;
+                            nameError.style.display = 'block';
+                        }
+                    })
+                    .catch(error => {
+                        // Re-enable button
+                        addTextButton.disabled = false;
+                        addTextButton.textContent = 'Add Text';
+                        
+                        // Show error message
+                        nameError.textContent = 'An error occurred. Please try again.';
+                        nameError.style.display = 'block';
+                        console.error('Error:', error);
+                    });
+                }
+            });
+        });
+    </script>
+</body>
+</html> 


### PR DESCRIPTION
This PR implements the feature to add new text files through a modal interface as described in issue #9. Key changes: Added new route '/new' that displays a modal for adding new text, created create_text.py to handle the backend logic for creating new text files, implemented proper CSV formatting with tilde separator, added style column with 'Normal' value, fixed UI styling for consistent padding in form fields, ensured proper redirection to the newly created file. Closes #9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced new endpoints that allow users to submit text entries with robust input validation, dynamic feedback, and proper error messaging.
  - Launched an interactive page for adding text entries, featuring a responsive design with dark mode support and client-side input validation.
  - Improved file selection by preserving previously chosen files for a more streamlined experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->