### PR TITLE
fix: Autosaving not working for all translated cells

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 15:30 on 13-03-2025
+- Fixed autosaving for translated cells
+  - Modified translate.py to save all translated cells to the database
+  - Ensured all cells with values are saved after translation, not just manually selected ones
+
 ## 22:54 on 10-03-2025
 - Migrated data storage from CSV to TinyDB
   - Added TinyDB dependency to the project

--- a/app/routes/translate.py
+++ b/app/routes/translate.py
@@ -5,6 +5,7 @@ def translate(self):
 
     from flask import render_template
     from models.auto_translate import auto_translate
+    from utils.db_operations import update_entry
     
     # Get the source column values
     column_values = self.data['source_string'].astype(str)
@@ -34,6 +35,11 @@ def translate(self):
     text = [re.sub(r'\[\[\d+\]\]', '', i) for i in text[1:]]
 
     self.data.iloc[:, 1] = text
+
+    # Save all translated cells to the database
+    filename = self.filename.replace('.csv', '')
+    for i, translation in enumerate(text):
+        update_entry(self.db_path, filename, i, 'target_string', translation)
 
     return render_template('index.html',
                             rows=self.data.values.tolist(),


### PR DESCRIPTION
## Description\nWhen the Translate feature fills all cells in the target column, only cells that were manually selected at least once before refresh are being saved. This PR fixes the issue by ensuring all cells with values are saved after translation, regardless of whether they were manually selected or not.\n\n## Changes\n- Modified translate.py to save all translated cells to the database after translation\n- Updated CHANGELOG.md to document the fix\n\n## Testing\n- Verified that all cells with values are saved after translation\n\nCloses #32

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced the autosave functionality for translations so that all translated cells are reliably saved automatically. Users will now experience a more consistent process where all translated content is preserved, improving the overall experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->