### PR TITLE
fix: make routes redirect to root path after operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,16 @@
   - Added User-Agent header to requests
   - Enhanced text cleaning to preserve Tibetan characters
 
+## 13:29 on 14-03-2025
+
+- Fixed routes to redirect to root path
+  - Modified commit.py to redirect to root after operation
+  - Modified publish.py to redirect to root after operation
+  - Modified translate.py to redirect to root after operation
+  - Modified review.py to redirect to root after operation
+  - Ensures consistent navigation experience for users
+  - Fixes issue #39
+
 ## 13:02 on 14-03-2025
 
 - Made Codecov integration optional in GitHub Actions workflow

--- a/app/routes/commit.py
+++ b/app/routes/commit.py
@@ -2,6 +2,7 @@ def commit(self):
 
     import subprocess
     import os
+    from flask import redirect, url_for
 
     try:
         # Get correct filename without .csv extension
@@ -18,4 +19,5 @@ def commit(self):
         
         print(f"An error occurred while committing to GitHub: {e}")
 
-    return '', 204
+    # Redirect to the root path instead of returning an empty response
+    return redirect(url_for('index'))

--- a/app/routes/publish.py
+++ b/app/routes/publish.py
@@ -2,6 +2,7 @@ def publish(self):
 
     from utils.get_env_vars import get_env_vars
     from models.publish_to_docs import publish_to_docs
+    from flask import redirect, url_for
 
     env_vars = get_env_vars(keys=['google_service_account_subject',
                                   'google_service_account_file'],
@@ -17,4 +18,5 @@ def publish(self):
         data_list,
         self.selected)
 
-    return '', 204
+    # Redirect to the root path instead of returning an empty response
+    return redirect(url_for('index'))

--- a/app/routes/review.py
+++ b/app/routes/review.py
@@ -3,6 +3,7 @@ def review(self):
         import re
         import json
         from utils.db_operations import update_entry, get_db
+        from flask import redirect, url_for
 
         from models.auto_review import auto_review
         
@@ -22,9 +23,9 @@ def review(self):
         # Join all formatted rows into a single string
         result_string = ''.join(formatted_rows)
 
-        # If no rows to review, return early
+        # If no rows to review, return early with redirect to root
         if not formatted_rows:
-            return '', 204
+            return redirect(url_for('index'))
 
         text = auto_review([result_string])
         response_text = f"{text}"
@@ -68,4 +69,5 @@ def review(self):
             print(f"Updating annotation for row {idx} with comment: {comment}")
             update_entry(self.db_path, filename, idx, 'annotation', comment)
 
-        return '', 204
+        # Redirect to the root path instead of returning an empty response
+        return redirect(url_for('index'))

--- a/app/routes/translate.py
+++ b/app/routes/translate.py
@@ -3,7 +3,7 @@ def translate(self):
     import re
     import json
 
-    from flask import render_template
+    from flask import render_template, redirect, url_for
     from models.auto_translate import auto_translate
     from utils.db_operations import update_entry
     
@@ -68,7 +68,5 @@ def translate(self):
     except Exception as e:
         print(f"Error saving translations to database: {str(e)}")
 
-    return render_template('index.html',
-                            rows=self.data.values.tolist(),
-                            files=self.all_files,
-                            selected=self.selected)
+    # Redirect to the root path instead of rendering the template directly
+    return redirect(url_for('index'))


### PR DESCRIPTION
This PR fixes issue #39 by making all routes redirect to the root path ('/') after completing their operations. Changes: Modified commit.py, publish.py, translate.py, and review.py to redirect to root after operation. This ensures a consistent navigation experience for users. Closes #39