### PR TITLE
fix: make annotation field visible in context pane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@
   - Updated the context pane to display "Annotations" as the heading
   - Added proper handling for empty annotations
   - Improved the display of annotation lists
+  - Added subtle styling for "No annotations for this row" message (italic, lighter color)
   - Fixes issue #37
 
 ## 13:29 on 14-03-2025

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,15 @@
   - Added User-Agent header to requests
   - Enhanced text cleaning to preserve Tibetan characters
 
+## 13:44 on 14-03-2025
+
+- Fixed annotation field visibility in context pane
+  - Modified get_context.py to properly access the annotation field from the database
+  - Updated the context pane to display "Annotations" as the heading
+  - Added proper handling for empty annotations
+  - Improved the display of annotation lists
+  - Fixes issue #37
+
 ## 13:29 on 14-03-2025
 
 - Fixed routes to redirect to root path

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,13 @@
   - Added User-Agent header to requests
   - Enhanced text cleaning to preserve Tibetan characters
 
+## 13:48 on 14-03-2025
+
+- Fixed HTML rendering in context pane
+  - Modified context_template.html to properly render HTML content using the |safe filter
+  - Ensures proper display of styled "No annotations for this row" message
+  - Improves visual consistency in the context pane
+
 ## 13:44 on 14-03-2025
 
 - Fixed annotation field visibility in context pane

--- a/app/routes/get_context.py
+++ b/app/routes/get_context.py
@@ -4,7 +4,7 @@ def get_context(self):
     
     import os
     import pandas as pd
-    from flask import jsonify, request
+    from flask import jsonify, request, render_template
     from utils.db_operations import get_all_entries
     
     try:
@@ -30,34 +30,52 @@ def get_context(self):
         
         row_index = int(request.json.get('row_index', 0))
         
-        # Check if the DataFrame has at least 4 columns (for review comments)
-        
         # Ensure the row index is valid
         if row_index >= len(self.data):
-           
             return jsonify({"result": "", "has_content": False})
         
-        # Check if we have a fourth column (index 3) for review comments
-        if self.data.shape[1] > 3:
-            # Get the value from the fourth column (index 3)
-            context_value = self.data.iloc[row_index, 3]
+        # Get the annotation field for the specified row
+        # The annotation field is a column in the DataFrame
+        if 'annotation' in self.data.columns:
+            annotation_value = self.data.iloc[row_index]['annotation']
             
-            
-            # Convert to string and handle NaN/None values
-            if pd.isna(context_value) or context_value is None or context_value == "":
-                
-                return jsonify({"result": "", "has_content": False})
+            # Check if the annotation is a list (as per the database structure)
+            if isinstance(annotation_value, list):
+                # If it's a list, check if it's empty
+                if not annotation_value:
+                    # Empty list, no annotations
+                    context_data = {
+                        "Annotations": "No annotations for this row"
+                    }
+                else:
+                    # List has items, render them
+                    context_data = {
+                        "Annotations": annotation_value
+                    }
             else:
-                context_value = str(context_value)
-                
-                # Add heading and content
-                formatted_content = f"<h3>Review Comment</h3><div class='review-content'>{context_value}</div>"
-                return jsonify({"result": formatted_content, "has_content": True})
-        else:
+                # If it's not a list or it's None/NaN
+                if pd.isna(annotation_value) or annotation_value is None or annotation_value == "":
+                    context_data = {
+                        "Annotations": "No annotations for this row"
+                    }
+                else:
+                    # Convert to string if it's not already
+                    context_data = {
+                        "Annotations": str(annotation_value)
+                    }
             
-            return jsonify({"result": "", "has_content": False})
+            # Render the context template with the data
+            rendered_html = render_template('context_template.html', data=context_data)
+            return jsonify({"result": rendered_html, "has_content": True})
+        else:
+            # If annotation column doesn't exist
+            context_data = {
+                "Annotations": "No annotations for this row"
+            }
+            rendered_html = render_template('context_template.html', data=context_data)
+            return jsonify({"result": rendered_html, "has_content": True})
+            
     except Exception as e:
-        
         import traceback
         traceback.print_exc()
         return jsonify({"result": f"Error: {str(e)}", "has_content": False}), 500

--- a/app/routes/get_context.py
+++ b/app/routes/get_context.py
@@ -45,7 +45,7 @@ def get_context(self):
                 if not annotation_value:
                     # Empty list, no annotations
                     context_data = {
-                        "Annotations": "No annotations for this row"
+                        "Annotations": "<span class='no-annotations-text'>No annotations for this row</span>"
                     }
                 else:
                     # List has items, render them
@@ -56,7 +56,7 @@ def get_context(self):
                 # If it's not a list or it's None/NaN
                 if pd.isna(annotation_value) or annotation_value is None or annotation_value == "":
                     context_data = {
-                        "Annotations": "No annotations for this row"
+                        "Annotations": "<span class='no-annotations-text'>No annotations for this row</span>"
                     }
                 else:
                     # Convert to string if it's not already
@@ -70,7 +70,7 @@ def get_context(self):
         else:
             # If annotation column doesn't exist
             context_data = {
-                "Annotations": "No annotations for this row"
+                "Annotations": "<span class='no-annotations-text'>No annotations for this row</span>"
             }
             rendered_html = render_template('context_template.html', data=context_data)
             return jsonify({"result": rendered_html, "has_content": True})

--- a/app/static/script.js
+++ b/app/static/script.js
@@ -486,15 +486,13 @@ document.addEventListener("DOMContentLoaded", function() {
         .then(data => {
             console.log("Response data:", data);
             if (data.has_content) {
-                // If there's content, display it (already formatted with heading)
+                // If there's content, display it (rendered HTML from template)
                 console.log("Has content, displaying:", data.result);
                 updateContextPane(data.result, false, true); // true for HTML content
             } else {
-                // If no content, display "No annotations" message
-                console.log("No content, displaying 'No annotations'");
-                const noAnnotationsHtml = `<h3 class="no-annotations-heading">No annotations</h3>
-                <div class="no-annotations-content">No review comments available for this text.</div>`;
-                updateContextPane(noAnnotationsHtml, false, true); // true for HTML content
+                // If no content, display empty context pane
+                console.log("No content, clearing context pane");
+                updateContextPane("", false);
             }
         })
         .catch(error => {

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -201,6 +201,13 @@
        margin: 4px 0 6px 0;
    }
    
+   /* Styling for "No annotations for this row" message */
+   .no-annotations-text {
+       font-style: italic;
+       color: #a0a0a0;  /* Light gray color */
+       font-size: 20px; /* Slightly smaller than regular context text */
+   }
+   
    .context-list {
        padding-left: 21px;
        margin: 4px 0 6px 0;

--- a/app/templates/context_template.html
+++ b/app/templates/context_template.html
@@ -1,4 +1,3 @@
-
 {% for key, value in data.items() %}
 
     <div class="context-section">
@@ -18,7 +17,7 @@
             </ul>
         
         {% else %}
-            <p class="context-text">{{ value }}</p>
+            <p class="context-text">{{ value|safe }}</p>
         {% endif %}
     
     </div>


### PR DESCRIPTION
This PR fixes issue #37 by making the annotation field from the database visible in the context pane. Changes include: Modified get_context.py to properly access the annotation field, updated the context pane to display 'Annotations' as the heading, added proper handling for empty annotations, and improved the display of annotation lists. Closes #37

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the annotation section in the context pane with a clear "Annotations" heading.
	- Enhanced the presentation of annotation lists, ensuring that empty or missing data is handled gracefully.
	- Streamlined content rendering for a more consistent and user-friendly experience.
  
- **New Features**
	- Introduced a styled message for cases with no annotations, enhancing visual clarity.
	- Updated HTML rendering to support formatted content in the context pane.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->