### PR TITLE
fix: update pandas to 2.2.1 for Python 3.12 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 19:30 on 14-03-2024
+- Updated pandas dependency for Python 3.12 compatibility
+  - Upgraded pandas from 2.1.0 to 2.2.1
+  - Resolves C extension compilation errors with Python 3.12
+  - Ensures compatibility with the latest Python version
+  - Maintains backward compatibility with existing code
+
 ## 14:25 on 14-03-2025
 - Fixed GitHub Actions workflow pytest command line error
   - Resolved exit code 4 issue by aligning with pytest.ini configuration

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 flask==2.3.3
 flask-session==0.5.0
-pandas==2.1.0
+pandas==2.2.1
 tinydb==4.8.0
 werkzeug==2.3.7 
 bokit


### PR DESCRIPTION
This PR updates the pandas dependency from 2.1.0 to 2.2.1 to fix compatibility issues with Python 3.12. The previous version was causing C extension compilation errors with Python 3.12.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Upgraded a key dependency to improve compatibility with Python 3.12 and resolve underlying build issues.
  
- **Documentation**
  - Updated release notes to reflect the dependency upgrade and workflow adjustments ensuring a smoother experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->